### PR TITLE
[CE-257] Add basic GA4 support

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 REACT_APP_ENVIRONMENT = production
 REACT_APP_DAG_EXPLORER_API_URL=https://l088pympe9.execute-api.us-east-1.amazonaws.com
+REACT_APP_GA4_MEASUREMENT_ID=G-XCQE4GHTWP

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-csv": "^2.2.2",
     "react-date-range": "^1.4.0",
     "react-dom": "^18.1.0",
+    "react-ga4": "^2.0.0",
     "react-query": "^3.39.1",
     "react-router-dom": "6",
     "react-tooltip": "^4.2.21",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,9 @@ import { BlockDetailsWrapper } from './views/BlocksView/Wrappers/BlockDetailsWra
 import { AddressDetailsWrapper } from './views/AddressView/Wrappers/AddressDetailsWrapper';
 import { Search } from './components/Search/Search';
 import { NodeExplorerWrapper } from './views/NodeExplorerView/NodeExplorerWrapper';
+import { initializeReactGaLib } from './utils/reactGoogleAnalytics';
+
+initializeReactGaLib();
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(

--- a/src/utils/reactGoogleAnalytics.ts
+++ b/src/utils/reactGoogleAnalytics.ts
@@ -1,0 +1,11 @@
+import ReactGA from 'react-ga4'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+const initializeReactGaLib = async () => {
+  await ReactGA.initialize(process.env.REACT_APP_GA_TRACKING_ID ?? '', {
+    testMode: !isProduction,
+  })
+}
+
+export { initializeReactGaLib }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7384,6 +7384,11 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-ga4@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.0.0.tgz#d125807cc30b087a6aa24401ec5f1f1c2d176fe9"
+  integrity sha512-WHi98hMunzh4ngRdNil8NN6Qly3ZZUkprhbgSqA+NFzovp8zqpYV3jcbKL9FnMdeBQHGhv8AVNCT2oFEE+EFXA==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Ticket: [CE-257](https://constellationnetwork.atlassian.net/browse/CE-257)

Just linking the site to a new GA4 property (DAG Explorer - GA4) on Constellation's analytics site.

[CE-257]: https://constellationnetwork.atlassian.net/browse/CE-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ