### PR TITLE
Add metagraph snapshot count on global snapshot detail

### DIFF
--- a/src/components/SnapshotDetail/SnapshotDetail.tsx
+++ b/src/components/SnapshotDetail/SnapshotDetail.tsx
@@ -174,6 +174,14 @@ export const SnapshotDetail = async ({
               </span>
             ),
           },
+          snapshot.metagraphSnashotCount !== undefined && {
+            label: "Metagraph snapshots",
+            value: (
+              <span className="flex items-center gap-2">
+                {snapshot.metagraphSnashotCount}
+              </span>
+            ),
+          },
           snapshot.fee !== undefined && {
             label: "Snapshot Fee",
             value: (

--- a/src/types/snapshots.ts
+++ b/src/types/snapshots.ts
@@ -21,6 +21,7 @@ export type IBESnapshot = {
   ownerAddress?: string | null;
   stakingAddress?: string | null;
   sizeInKb?: number;
+  metagraphSnashotCount?: number;
 };
 
 export type IAPISnapshot = IBESnapshot & {


### PR DESCRIPTION
### Changes

+ Add support for metagraph snapshot count on global snapshot detail page.

### Screenshots
![image](https://github.com/user-attachments/assets/38223cec-db44-4a87-89d4-d83d4e31dce8)
